### PR TITLE
Removing Check for bits 2 to 7 of Message Control Headers in PDVs

### DIFF
--- a/pdu/pdu.go
+++ b/pdu/pdu.go
@@ -421,9 +421,6 @@ func ReadPresentationDataValueItem(d *dicomio.Decoder) PresentationDataValueItem
 	item.Command = (header&1 != 0)
 	item.Last = (header&2 != 0)
 	item.Value = d.ReadBytes(int(length - 2)) // remove contextID and header
-	if header&0xfc != 0 {
-		d.SetError(fmt.Errorf("PresentationDataValueItem: illegal header byte %x", header))
-	}
 	return item
 }
 


### PR DESCRIPTION
According to P3.8, E.2 (http://dicom.nema.org/medical/dicom/current/output/html/part08.html#sect_E.2), "Bits 2 through 7 are always set to 0 by the sender and never checked by the receiver.".