### PR TITLE
Completing user information on A-ASSOCIATE

### DIFF
--- a/contextmanager.go
+++ b/contextmanager.go
@@ -160,9 +160,16 @@ func (m *contextManager) onAssociateRequest(requestItems []pdu.SubItem) ([]pdu.S
 			}
 		}
 	}
+	// PS3.7, D.3.3
 	responses = append(responses,
 		&pdu.UserInformationItem{
-			Items: []pdu.SubItem{&pdu.UserInformationMaximumLengthItem{MaximumLengthReceived: uint32(DefaultMaxPDUSize)}}})
+			Items: []pdu.SubItem{
+				&pdu.UserInformationMaximumLengthItem{MaximumLengthReceived: uint32(DefaultMaxPDUSize)},
+				&pdu.ImplementationClassUIDSubItem{Name: dicom.GoDICOMImplementationClassUID},
+				&pdu.ImplementationVersionNameSubItem{Name: dicom.GoDICOMImplementationVersionName},
+			},
+		},
+	)
 	dicomlog.Vprintf(1, "dicom.onAssociateRequest(%s): Received associate request, #contexts:%v, maxPDU:%v, implclass:%v, version:%v",
 		m.label, len(m.contextIDToAbstractSyntaxNameMap),
 		m.peerMaxPDUSize, m.peerImplementationClassUID, m.peerImplementationVersionName)


### PR DESCRIPTION
Adding Implementation Class UID and Implementation Version Name to A-ASSOCIATE-AC.

According to PS3.7, D.3.3 (http://dicom.nema.org/medical/dicom/current/output/html/part07.html#sect_D.3.3),
it is mandatory to include Implementation Class UID sub-item in both A-ASSOCIATE-RQ and A-ASSOCIATE-AC.